### PR TITLE
fix: register treesitter update function

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Then, install the plugin with your preferred package manager.
 { "ethanuppal/spade.nvim" }
 ```
 
+After installing the plugin with Lazy, install the treesitter parser with
+`:TSInstall spade`.
+
 You can supply configuration with the optional `opts` field, as in
 
 ```lua
@@ -78,6 +81,9 @@ use {
     requires = {{ "nvim-treesitter/nvim-treesitter" }}
 }
 ```
+
+After installing the plugin with Packer, install the treesitter parser with
+`:TSInstall spade`.
 
 <a name="help"></a>
 

--- a/lua/spade/init.lua
+++ b/lua/spade/init.lua
@@ -79,25 +79,18 @@ local function install_command()
 	})
 end
 
-local function setup_treesitter()
-	-- see https://github.com/nvim-treesitter/nvim-treesitter
-	require("nvim-treesitter.install").prefer_git = true
-	require("nvim-treesitter.parsers").get_parser_configs()["spade"] = {
-		install_info = {
-			url = "https://gitlab.com/spade-lang/tree-sitter-spade/",
-			files = { "src/parser.c" },
-			branch = "main",
-			generate_requires_npm = false,
-			requires_generate_from_grammar = false,
-		},
-		filetype = "spade",
-	}
-
-	-- update or install the grammar
-	if_online(function()
-		vim.cmd.TSUpdate("spade")
-	end)
-end
+vim.api.nvim_create_autocmd("User", {
+	pattern = "TSUpdate",
+	callback = function()
+		require("nvim-treesitter.parsers").spade = {
+			install_info = {
+				url = "https://gitlab.com/spade-lang/tree-sitter-spade",
+				branch = "main",
+				files = { "src/parser.c" },
+			},
+		}
+	end,
+})
 
 local function start_lsp()
 	if M.swim_root_dir() ~= nil then
@@ -112,11 +105,6 @@ local function start_lsp()
 	end
 end
 
-local function setup_plugin()
-	install_command()
-	setup_treesitter()
-end
-
 function M.setup(opts)
 	M.config = vim.tbl_deep_extend("force", M.config, opts or {})
 
@@ -124,7 +112,7 @@ function M.setup(opts)
 		vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
 			pattern = "*.spade",
 			callback = function()
-				setup_plugin()
+				install_command()
 			end,
 			once = true,
 		})
@@ -135,7 +123,7 @@ function M.setup(opts)
 			end,
 		})
 	else
-		setup_plugin()
+		install_command()
 		start_lsp()
 	end
 end


### PR DESCRIPTION
Hi, thanks for the plugin!
When I tried to use it, I had some trouble to get it working.
I think because of the nvim-treesitter updates some changes are necessary.
Not so familiar with all this, so this is my best effort to make it work, let me know if I should change something!

```sh
Failed to run `config` for spade.nvim

.local/share/nvim/lazy/spade.nvim/lua/spade/init.lua:85: attempt to call field 'get_parser_configs' (a nil value)
```


The fix updates the usage of `nvim-treesitter` for the now default 'main' branch, which does not use `get_parser_configs()` anymore. Additionally, instead of calling the setup function each time nvim is started, register spade for `:TSUpdate`.
This now requires the user to use `:TSInstall spade` once after the plugin is installed.